### PR TITLE
chore: use raw commit message in last_commit lookup

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -18,7 +18,7 @@ MERGES=($MERGES)
 
 IFS=$SAVEDIFS
 
-LAST_COMMIT=$(git log -1 --pretty=format:%b)
+LAST_COMMIT=$(git log -1 --pretty=format:%B)
 
 TASKS=()
 


### PR DESCRIPTION
The use of `%b` only extract the body of the commit message. When a commit only has one line, the last commit is always empty, because the message only has a subject. Using %B we can match the issue ID all along the message.
In our team, we apply the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/), where the use of body in a commit message is optional. Almost all of our regular commit messages are one line and the step is not compatible with them.

You can reproduce the issue making a commit like
`git commit -m "fix(AR-252): my description of the changes"`

And then run the same command that is used to extract last commit
`LAST_COMMIT=$(git log -1 --pretty=format:%b)`

LAST_COMMIT will be empty. If we change the `%b` to `%B` we can catch this kind of cases, and we are still compatible with the rest of the commits that have subject and body.

Pretty formats docs:
https://git-scm.com/docs/pretty-formats